### PR TITLE
Soft filtering added

### DIFF
--- a/examples/4_mine_and_craft.py
+++ b/examples/4_mine_and_craft.py
@@ -201,7 +201,7 @@ def getSticks(rob):
             runStraight(rob, lookAt(rob, target), True)
         target = rob.nearestFromGrid('log')
 
-    while rob.filterInventoryItem('log') != []: # [] != None as well
+    while rob.softFilterInventoryItem('log') != []: # [] != None as well
         rob.craft('planks')
 
     rob.craft('stick')

--- a/tagilmo/utils/malmo_wrapper.py
+++ b/tagilmo/utils/malmo_wrapper.py
@@ -9,7 +9,6 @@ import logging
 import collections
 import re
 
-import MalmoPython as MP
 import VereyaPython as VP
 
 import numpy
@@ -78,7 +77,7 @@ class MalmoConnector:
                     self.agent_hosts[role].startMission(self.mission, self.client_pool, self.mission_record, role, expId)
                     #self.agent_hosts[role].startMission(self.mission, self.mission_record)
                     break
-                except (MP.MissionException, VP.MissionException) as e:
+                except (VP.MissionException) as e:
                     errorCode = e.details.errorCode
                     if errorCode == VP.MissionErrorCode.MISSION_SERVER_WARMING_UP:
                         print("Server not quite ready yet - waiting...")
@@ -512,6 +511,10 @@ class RobustObserver:
     def filterInventoryItem(self, item, observeReq=True):
         inv = self.waitNotNoneObserve('getInventory', True, observeReq=observeReq)
         return list(filter(lambda entry: entry['type']==item, inv))
+
+    def softFilterInventoryItem(self, item, observeReq=True):
+        inv = self.waitNotNoneObserve('getInventory', True, observeReq=observeReq)
+        return list(filter(lambda entry: item in entry['type'], inv))
 
     def nearestFromGrid(self, objs, observeReq=True):
         if not isinstance(objs, list):


### PR DESCRIPTION
Function soft filtering is added to address an issue, where in current 1.18 minecraft version we want to filter inventory to find some logs but there are logs with prefix (oak_log, birch_log etc). So now softFiltering allows us to find "log" in "oak_log" and use it further.
@noskill 
@CICS-Oleg 