### PR TITLE
Read recipes from Vereya and convert to current format

### DIFF
--- a/examples/6_achiever.py
+++ b/examples/6_achiever.py
@@ -57,8 +57,19 @@ if __name__ == '__main__':
     sleep(0.1)
     agent.rob.sendCommand("jump 0")
 
+
     #initialize_minelogy
     mlogy = Minelogy(agent.getVersion())
+    '''
+    Currently we don't use all recipes from the game since there are some issues with
+    agent not be able to work properly with all recipes available
+    '''
+
+    # agent.rob.sendCommand('recipes')
+    # sleep(2)
+    # recipes = agent.rob.mc.observe[0]['recipes']
+    # mlogy.set_recipes(recipes)
+
     agent.set_mlogy(mlogy)
 
     agent.run()

--- a/examples/minelogy.py
+++ b/examples/minelogy.py
@@ -96,7 +96,7 @@ class Minelogy():
                   {'type': 'wheat_seeds'}
                   ),
                  ]
-
+        # self.crafts = []
         self.crafts = [([{'type': 'log', 'quantity': 1}],
                    {'type': 'planks', 'quantity': 4}),
                   ([{'type': 'planks', 'quantity': 2}],
@@ -159,6 +159,30 @@ class Minelogy():
                    {"type": "boat", "quantity": 1})
                   ]
         self.initialize_minelogy(mcver)
+
+    def set_recipes(self, mcrecipes):
+        self.crafts = []
+        for mcrecipe in mcrecipes:
+            craft_name = mcrecipe['name'].split('.')[-1]
+            craft_quantity = mcrecipe['count']
+            ingredients = {}
+            craft_ingredients = []
+            for material in mcrecipe['ingredients']:
+                if len(material) == 0:
+                    continue
+                material_name = material[0]['type'].split(".")[-1]
+                if material_name not in ingredients:
+                    ingredients[material_name] = 1
+                else:
+                    ingredients[material_name] += 1
+            for ingredient in ingredients:
+                craft_ingredients.append({'type' : ingredient, 'quantity' : ingredients[ingredient]})
+            if len(craft_ingredients) == 0:
+                continue
+            craft_entity = (craft_ingredients,
+                    {'type': craft_name, 'quantity': craft_quantity})
+            if (craft_entity not in self.crafts) and (len(craft_entity) > 0):
+                self.crafts.append(craft_entity)
 
     def initialize_minelogy(self, mc_ver):
         mcd = minecraft_data(mc_ver.split("-")[-1])


### PR DESCRIPTION
So, I've added function for minelogy which gets recipes from MCConnector and converts them to current format we're using in crafts list. Since there are some issues using those full pack of recipes inside our current agent, this functionality wasn't added to any agent. 

One more problem we have here is that recipes doesn't contain necessary tools for craft. What i mean is that if we need furnace  to melt some iron (or stonecutter, or anything like that), we won't get this info from vereya's recipes. 