### PR TITLE
Platform-dependent visualizer

### DIFF
--- a/mcdemoaux/vision/vis.py
+++ b/mcdemoaux/vision/vis.py
@@ -58,13 +58,13 @@ class VisualizerBlank():
     def run(self):
         pass
 
-def Visualizer(blankvis=False):
+def Visualizer(blankvis=None):
     ostype = platform.system()
-    if blankvis:
+    if (blankvis is None and ostype == 'Darwin') or blankvis == True:
         return VisualizerBlank()
-    elif (ostype == 'Darwin'):
+    elif blankvis == False and ostype == 'Darwin':
         return VisualizerMac()
-    elif (ostype == 'Linux' or ostype == 'Windows'):
+    elif (blankvis is None or blankvis == False) and (ostype == 'Linux' or ostype == 'Windows'):
         return VisualizerThreaded()
     else:
         print("unknown OS type, initializing blank Visualizer\n")

--- a/mcdemoaux/vision/vis.py
+++ b/mcdemoaux/vision/vis.py
@@ -1,9 +1,9 @@
 from collections import deque
 import threading
 import cv2
+import platform
 
-
-class Visualizer(threading.Thread):
+class VisualizerThreaded(threading.Thread):
     def __init__(self):
         super().__init__(name='visualization', daemon=False)
         self.queue = deque(maxlen=10)
@@ -25,3 +25,48 @@ class Visualizer(threading.Thread):
                 cv2.imshow(data[0], data[1])
             cv2.waitKey(300)
 
+class VisualizerMac():
+    def __init__(self):
+        self.queue = deque(maxlen=10)
+
+    def __call__(self, *args):
+        cv2.imshow(args[0], args[1])
+        cv2.waitKey(1)
+
+    def stop(self):
+        pass
+
+    def start(self):
+        pass
+
+    def run(self):
+        pass
+
+class VisualizerBlank():
+    def __init__(self):
+        pass
+
+    def __call__(self, *args):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def run(self):
+        pass
+
+def Visualizer(blankvis=False):
+    ostype = platform.system()
+    return VisualizerMac()
+    if blankvis:
+        return VisualizerBlank()
+    elif (ostype == 'Darwin'):
+        return VisualizerMac()
+    elif (ostype == 'Linux' or ostype == 'Windows'):
+        return VisualizerThreaded()
+    else:
+        print("unknown OS type, initializing blank Visualizer\n")
+        return VisualizerBlank()

--- a/mcdemoaux/vision/vis.py
+++ b/mcdemoaux/vision/vis.py
@@ -60,7 +60,6 @@ class VisualizerBlank():
 
 def Visualizer(blankvis=False):
     ostype = platform.system()
-    return VisualizerMac()
     if blankvis:
         return VisualizerBlank()
     elif (ostype == 'Darwin'):


### PR DESCRIPTION
It also can be deactivated using `blankvis=True` when calling Visualizer (now it is function which instance of one of visualizer).