### PR TITLE
videoproducer can accept 0 height/width

### DIFF
--- a/mcdemoaux/agenttools/agent.py
+++ b/mcdemoaux/agenttools/agent.py
@@ -13,7 +13,13 @@ class TAgent:
         self.rob = RobustObserverWithCallbacks(mc)
         vp = miss.agentSections[0].agenthandlers.video_producer
         if vp is not None:
-            callback = NeuralWrapper(self.rob, 320/vp.width, vp.width//320)
+            if vp.width == 0:
+                #it is probably shouldn't be there. Currently a stub
+                SCALE = 3
+                width = 320 * SCALE
+                callback = NeuralWrapper(self.rob, 320 / width, width // 320)
+            else:
+                callback = NeuralWrapper(self.rob, 320/vp.width, vp.width//320)
                                     # cb_name, on_change event, callback
             self.rob.addCallback('getNeuralSegmentation', 'getImageFrame', callback)
         self.blockMem = NoticeBlocks()

--- a/tagilmo/VereyaPython/mission_spec.py
+++ b/tagilmo/VereyaPython/mission_spec.py
@@ -50,16 +50,16 @@ class MissionSpec:
 
     def _getVideoHW(self, role: int, hw) -> int:
         w = self.getRoleValue(role, "AgentHandlers.VideoProducer", hw)
-        if w:
+        if w is not None:
             return w
         w = self.getRoleValue(role, "AgentHandlers.DepthProducer", hw)
-        if w:
+        if w is not None:
             return w
         w = self.getRoleValue(role, "AgentHandlers.LuminanceProducer", hw)
-        if w:
+        if w is not None:
             return w
         w = self.getRoleValue(role, "AgentHandlers.ColourMapProducer", hw)
-        if w:
+        if w is not None:
             return w
         raise RuntimeError("MissionInitSpec::getVideoWidth : video has not been requested for this role")
 

--- a/tagilmo/utils/mission_builder.py
+++ b/tagilmo/utils/mission_builder.py
@@ -222,7 +222,7 @@ class Observations:
 
 
 class VideoProducer:
-    def __init__(self, height, width, want_depth=False):
+    def __init__(self, height=0, width=0, want_depth=False):
         self.height = height
         self.width = width
         self.want_depth = want_depth


### PR DESCRIPTION
Ok, so it is weird, but I have no need to make any changes to Vereya to make this work. At least for linux. Probably this should be tested on other OS. 

I've tested using achiever with deleted width and height in the VideoProducer call.

In agent.py there are some probably not right changes so it won't fail when width of video producer is 0. I think we should use height/width received from the vereya? I'll think of it more.

Also, in mission_spec.py I've changed `if w` to `if w is not None` since it will fail when width = 0 (0 == False). I'm not sure this solution is good either.