### PR TITLE
remove scale from neural

### DIFF
--- a/mcdemoaux/agenttools/agent.py
+++ b/mcdemoaux/agenttools/agent.py
@@ -12,13 +12,7 @@ class TAgent:
             mc.safeStart()
         self.rob = RobustObserverWithCallbacks(mc)
         if mc.mission.isVideoRequested(0):
-            w = mc.mission.getVideoWidth(0)
             callback = NeuralWrapper(self.rob)
-            # if w == 0:
-            #     callback = NeuralWrapper(self.rob, 1, 1)
-            # else:
-            #     callback = NeuralWrapper(self.rob, 320/w, w//320)
-                                    # cb_name, on_change event, callback
             self.rob.addCallback('getNeuralSegmentation', 'getImageFrame', callback)
         self.blockMem = NoticeBlocks()
         self.visualizer = visualizer

--- a/mcdemoaux/agenttools/agent.py
+++ b/mcdemoaux/agenttools/agent.py
@@ -13,10 +13,11 @@ class TAgent:
         self.rob = RobustObserverWithCallbacks(mc)
         if mc.mission.isVideoRequested(0):
             w = mc.mission.getVideoWidth(0)
-            if w == 0:
-                callback = NeuralWrapper(self.rob, 1, 1)
-            else:
-                callback = NeuralWrapper(self.rob, 320/w, w//320)
+            callback = NeuralWrapper(self.rob)
+            # if w == 0:
+            #     callback = NeuralWrapper(self.rob, 1, 1)
+            # else:
+            #     callback = NeuralWrapper(self.rob, 320/w, w//320)
                                     # cb_name, on_change event, callback
             self.rob.addCallback('getNeuralSegmentation', 'getImageFrame', callback)
         self.blockMem = NoticeBlocks()

--- a/mcdemoaux/vision/neural.py
+++ b/mcdemoaux/vision/neural.py
@@ -8,35 +8,34 @@ import cv2
 model_cache = dict()
 
 
-def process_pixel_data(pixels, resize, scale):
+def process_pixel_data(pixels):
     # img_data = numpy.frombuffer(pixels, dtype=numpy.uint8)
-    img_data = cv2.resize(pixels, dsize=(320 * scale, 240 * scale), interpolation=cv2.INTER_CUBIC)
+    img_data = cv2.resize(pixels, dsize=(320, 240), interpolation=cv2.INTER_CUBIC)
     # img_data = numpy.resize(pixels, (240 * scale, 320 * scale, 4))
     # img_data = pixels
-    if resize != 1:
-        height, width, _ = img_data.shape
-        img_data = cv2.resize(img_data, (int(width * resize), int(height * resize)),
-            fx=resize, fy=resize, interpolation=cv2.INTER_NEAREST)
+    # if resize != 1:
+    #     height, width, _ = img_data.shape
+    #     img_data = cv2.resize(img_data, (int(width * resize), int(height * resize)),
+    #         fx=resize, fy=resize, interpolation=cv2.INTER_NEAREST)
 
     return img_data
 
 
-def get_image(img_frame, resize, scale):
+def get_image(img_frame):
     if img_frame is not None:
-        return process_pixel_data(img_frame.pixels, resize, scale)
+        return process_pixel_data(img_frame.pixels)
     return None
 
 
 class NeuralWrapper:
-    def __init__(self, rob, resize, scale):
+    def __init__(self, rob):
         self.net = self.load_model()
         self.rob = rob
-        self.resize = resize
-        self.scale = scale
 
     def _get_image(self):
         img_name = 'getImageFrame'
-        img_data = get_image(self.rob.getCachedObserve(img_name), self.resize, self.scale)
+        img_data = get_image(self.rob.getCachedObserve(img_name))
+        # img_data = self.rob.getCachedObserve(img_name).pixels
         if img_data is not None:
             img_data = torch.as_tensor(img_data).permute(2,0,1)
             img_data = img_data.unsqueeze(0) / 255.0

--- a/mcdemoaux/vision/neural.py
+++ b/mcdemoaux/vision/neural.py
@@ -12,7 +12,7 @@ def process_pixel_data(pixels, keep_aspect_ratio=False, maximum_area=None):
     # img_data = numpy.frombuffer(pixels, dtype=numpy.uint8)
     height, width, _ = pixels.shape
     wscale = width / 320
-    if not keep_aspect_ratio:
+    if keep_aspect_ratio:
         hscale = height / 240
     else:
         hscale = wscale

--- a/mcdemoaux/vision/neural.py
+++ b/mcdemoaux/vision/neural.py
@@ -8,24 +8,42 @@ import cv2
 model_cache = dict()
 
 
+# def process_pixel_data(pixels, keep_aspect_ratio, maximum_size):
+#     height, width, _ = pixels.shape
+#     aspect_ratio_org = width / height
+#     wscale = width // 320
+#     scaled_width = int(320*wscale)
+#     scaled_height = int(int(keep_aspect_ratio) * (scaled_width / aspect_ratio_org) + (1 - int(keep_aspect_ratio)) * int(240*wscale))
+#     if maximum_size is not None and maximum_size:
+#         scaled_width = maximum_size[0] if scaled_width > maximum_size[0] else scaled_width
+#         if keep_aspect_ratio:
+#             scaled_height = int(scaled_width / aspect_ratio_org)
+#         else:
+#             scaled_height = maximum_size[1] if scaled_height > maximum_size[1] else scaled_height
+#
+#     # to make width and height divisible by 8
+#     scaled_width -= scaled_width % 8
+#     scaled_height -= scaled_height % 8
+#
+#     img_data = cv2.resize(pixels, dsize=(scaled_width, scaled_height), interpolation=cv2.INTER_CUBIC)
+#
+#     return img_data
+
 def process_pixel_data(pixels, keep_aspect_ratio, maximum_size):
     height, width, _ = pixels.shape
     aspect_ratio_org = width / height
-    wscale = width // 320
-    scaled_width = int(320*wscale)
-    scaled_height = int(int(keep_aspect_ratio) * (scaled_width / aspect_ratio_org) + (1 - int(keep_aspect_ratio)) * int(240*wscale))
     if maximum_size is not None and maximum_size:
-        scaled_width = maximum_size[0] if scaled_width > maximum_size[0] else scaled_width
+        width = maximum_size[0] if width > maximum_size[0] else width
         if keep_aspect_ratio:
-            scaled_height = int(scaled_width / aspect_ratio_org)
+            height = int(height / aspect_ratio_org)
         else:
-            scaled_height = maximum_size[1] if scaled_height > maximum_size[1] else scaled_height
+            height = maximum_size[1] if height > maximum_size[1] else height
 
     # to make width and height divisible by 8
-    scaled_width -= scaled_width % 8
-    scaled_height -= scaled_height % 8
+    width -= width % 8
+    height -= height % 8
 
-    img_data = cv2.resize(pixels, dsize=(scaled_width, scaled_height), interpolation=cv2.INTER_CUBIC)
+    img_data = cv2.resize(pixels, dsize=(width, height), interpolation=cv2.INTER_CUBIC)
 
     return img_data
 

--- a/mcdemoaux/vision/neural.py
+++ b/mcdemoaux/vision/neural.py
@@ -8,50 +8,44 @@ import cv2
 model_cache = dict()
 
 
-def process_pixel_data(pixels, keep_aspect_ratio=False, maximum_area=None):
-    # img_data = numpy.frombuffer(pixels, dtype=numpy.uint8)
+def process_pixel_data(pixels, keep_aspect_ratio, maximum_size):
     height, width, _ = pixels.shape
-    wscale = width / 320
-    if keep_aspect_ratio:
-        hscale = height / 240
-    else:
-        hscale = wscale
-
+    aspect_ratio_org = width / height
+    wscale = width // 320
     scaled_width = int(320*wscale)
-    scaled_height = int(240*hscale)
+    scaled_height = int(int(keep_aspect_ratio) * (scaled_width / aspect_ratio_org) + (1 - int(keep_aspect_ratio)) * int(240*wscale))
+    if maximum_size is not None and maximum_size:
+        scaled_width = maximum_size[0] if scaled_width > maximum_size[0] else scaled_width
+        if not keep_aspect_ratio:
+            scaled_height = maximum_size[1] if scaled_height > maximum_size[1] else scaled_height
+        else:
+            scaled_height = int(scaled_width / aspect_ratio_org)
 
-    #to make width and height divisible by 8
+    # to make width and height divisible by 8
     scaled_width -= scaled_width % 8
     scaled_height -= scaled_height % 8
 
     img_data = cv2.resize(pixels, dsize=(scaled_width, scaled_height), interpolation=cv2.INTER_CUBIC)
-    # img_data = numpy.resize(pixels, (240 * scale, 320 * scale, 4))
-    # img_data = pixels
-    # if resize != 1:
-    #     height, width, _ = img_data.shape
-    #     img_data = cv2.resize(img_data, (int(width * resize), int(height * resize)),
-    #         fx=resize, fy=resize, interpolation=cv2.INTER_NEAREST)
 
     return img_data
 
 
-def get_image(img_frame, keep_aspect_ratio=False, maximum_area=None):
+def get_image(img_frame, keep_aspect_ratio, maximum_size):
     if img_frame is not None:
-        return process_pixel_data(img_frame.pixels, keep_aspect_ratio, maximum_area)
+        return process_pixel_data(img_frame.pixels, keep_aspect_ratio, maximum_size)
     return None
 
 
 class NeuralWrapper:
-    def __init__(self, rob, keep_aspect_ratio=False, maximum_area=None):
+    def __init__(self, rob, keep_aspect_ratio=False, maximum_size=(320, 240)):
         self.net = self.load_model()
         self.rob = rob
         self.keep_aspect_ratio = keep_aspect_ratio
-        self.maximum_area = maximum_area
+        self.maximum_size = maximum_size
 
     def _get_image(self):
         img_name = 'getImageFrame'
-        img_data = get_image(self.rob.getCachedObserve(img_name), self.keep_aspect_ratio, self.maximum_area)
-        # img_data = self.rob.getCachedObserve(img_name).pixels
+        img_data = get_image(self.rob.getCachedObserve(img_name), self.keep_aspect_ratio, self.maximum_size)
         if img_data is not None:
             img_data = torch.as_tensor(img_data).permute(2,0,1)
             img_data = img_data.unsqueeze(0) / 255.0

--- a/mcdemoaux/vision/neural.py
+++ b/mcdemoaux/vision/neural.py
@@ -7,28 +7,6 @@ import cv2
 
 model_cache = dict()
 
-
-# def process_pixel_data(pixels, keep_aspect_ratio, maximum_size):
-#     height, width, _ = pixels.shape
-#     aspect_ratio_org = width / height
-#     wscale = width // 320
-#     scaled_width = int(320*wscale)
-#     scaled_height = int(int(keep_aspect_ratio) * (scaled_width / aspect_ratio_org) + (1 - int(keep_aspect_ratio)) * int(240*wscale))
-#     if maximum_size is not None and maximum_size:
-#         scaled_width = maximum_size[0] if scaled_width > maximum_size[0] else scaled_width
-#         if keep_aspect_ratio:
-#             scaled_height = int(scaled_width / aspect_ratio_org)
-#         else:
-#             scaled_height = maximum_size[1] if scaled_height > maximum_size[1] else scaled_height
-#
-#     # to make width and height divisible by 8
-#     scaled_width -= scaled_width % 8
-#     scaled_height -= scaled_height % 8
-#
-#     img_data = cv2.resize(pixels, dsize=(scaled_width, scaled_height), interpolation=cv2.INTER_CUBIC)
-#
-#     return img_data
-
 def process_pixel_data(pixels, keep_aspect_ratio, maximum_size):
     height, width, _ = pixels.shape
     aspect_ratio_org = width / height
@@ -55,7 +33,7 @@ def get_image(img_frame, keep_aspect_ratio, maximum_size):
 
 
 class NeuralWrapper:
-    def __init__(self, rob, keep_aspect_ratio=True, maximum_size=(320, 240)):
+    def __init__(self, rob, keep_aspect_ratio=True, maximum_size=(384, 240)):
         self.net = self.load_model()
         self.rob = rob
         self.keep_aspect_ratio = keep_aspect_ratio

--- a/mcdemoaux/vision/neural.py
+++ b/mcdemoaux/vision/neural.py
@@ -33,11 +33,11 @@ def process_pixel_data(pixels, keep_aspect_ratio, maximum_size):
     height, width, _ = pixels.shape
     aspect_ratio_org = width / height
     if maximum_size is not None and maximum_size:
-        width = maximum_size[0] if width > maximum_size[0] else width
+        height = maximum_size[1] if height > maximum_size[1] else height
         if keep_aspect_ratio:
-            height = int(height / aspect_ratio_org)
+            width = int(height * aspect_ratio_org)
         else:
-            height = maximum_size[1] if height > maximum_size[1] else height
+            width = maximum_size[0] if width > maximum_size[0] else width
 
     # to make width and height divisible by 8
     width -= width % 8

--- a/mcdemoaux/vision/neural.py
+++ b/mcdemoaux/vision/neural.py
@@ -16,10 +16,10 @@ def process_pixel_data(pixels, keep_aspect_ratio, maximum_size):
     scaled_height = int(int(keep_aspect_ratio) * (scaled_width / aspect_ratio_org) + (1 - int(keep_aspect_ratio)) * int(240*wscale))
     if maximum_size is not None and maximum_size:
         scaled_width = maximum_size[0] if scaled_width > maximum_size[0] else scaled_width
-        if not keep_aspect_ratio:
-            scaled_height = maximum_size[1] if scaled_height > maximum_size[1] else scaled_height
-        else:
+        if keep_aspect_ratio:
             scaled_height = int(scaled_width / aspect_ratio_org)
+        else:
+            scaled_height = maximum_size[1] if scaled_height > maximum_size[1] else scaled_height
 
     # to make width and height divisible by 8
     scaled_width -= scaled_width % 8
@@ -37,7 +37,7 @@ def get_image(img_frame, keep_aspect_ratio, maximum_size):
 
 
 class NeuralWrapper:
-    def __init__(self, rob, keep_aspect_ratio=False, maximum_size=(320, 240)):
+    def __init__(self, rob, keep_aspect_ratio=True, maximum_size=(320, 240)):
         self.net = self.load_model()
         self.rob = rob
         self.keep_aspect_ratio = keep_aspect_ratio


### PR DESCRIPTION
it works of course. I'm not sutre if we need to resize to 320*240 every time, but when I'm using original size, I've found some artifacts on the "leaves" window. It always shows that there are many leaves, even when i'm looking into the sky.

Of course all commented code will be deleted. It's just a draft right now.

Update: well, I've tested some more and now i can't reproduce those artifacts even with resize size larger than player's window.