### PR TITLE
Some refactor and events added to vereya wrapper

### DIFF
--- a/examples/skills.py
+++ b/examples/skills.py
@@ -834,7 +834,7 @@ class ListenAndDo(Switcher):
         self.terminate = False
 
     def update(self):
-        command = self.rob.getCachedObserve('getChat')
+        command = self.rob.getCachedObserve('getChat')[-1][0]
         if self.next_goal is not None:
             self.delegate = self.next_goal
             self.next_goal = None

--- a/examples/skills.py
+++ b/examples/skills.py
@@ -834,21 +834,24 @@ class ListenAndDo(Switcher):
         self.terminate = False
 
     def update(self):
-        command = self.rob.getCachedObserve('getChat')[-1][0]
-        if self.next_goal is not None:
-            self.delegate = self.next_goal
-            self.next_goal = None
-        elif command is not None:
-            words = command[0].split(' ')
-            if words[-1] == 'terminate':
-                self.terminate = True
-            if len(words) > 1:
-                if words[-2] == 'get':
-                    self.next_goal = Obtain(self.agent, [{'type': words[-1]}])
+        commands = self.rob.getCachedObserve('getChat')
+        for command in reversed(commands):
+            command = command[0]
             if self.next_goal is not None:
-                print("Received command: ", command)
-                if self.delegate is not None:
-                    self.stopDelegate = True
+                self.delegate = self.next_goal
+                self.next_goal = None
+            elif command is not None:
+                words = command[0].split(' ')
+                if words[-1] == 'terminate':
+                    self.terminate = True
+                if len(words) > 1:
+                    if words[-2] == 'get':
+                        self.next_goal = Obtain(self.agent, [{'type': words[-1]}])
+                if self.next_goal is not None:
+                    print("Received command: ", command)
+                    if self.delegate is not None:
+                        self.stopDelegate = True
+                break
         super().update()
 
     def finished(self):

--- a/tagilmo/utils/vereya_wrapper.py
+++ b/tagilmo/utils/vereya_wrapper.py
@@ -493,8 +493,6 @@ class RobustObserver:
     def _update_cache(self, method):
         t_new = time.time()
         v_new = getattr(self.mc, method)(self.nAgent)
-        if v_new is None and method in self.events and not self.readEvents[method]:
-            return
         outdated = False
         with self.lock:
             if method not in self.events:

--- a/tagilmo/utils/vereya_wrapper.py
+++ b/tagilmo/utils/vereya_wrapper.py
@@ -473,7 +473,7 @@ class RobustObserver:
     def getCachedObserve(self, method, key = None):
         with self.lock:
             val = self.cached[method]
-        if method in self.events and val is not None:
+        if method in self.events:
             self.readEvents[method] = True
             self.cached[method] = [(None, 0)]
         else:


### PR DESCRIPTION
So, this is my understanding of yesterday's words of Alexey about splitting methods to events and states. As I understand, principle of states update is the same as before, so I haven't changed anything for them. I've added events and I'm changing them currently only if agent read info from cached event OR if new event happened (for example, we haven't read chat but it was already been changed to something else). I don't know if we need to convert events to lists and loop through all of them on read?

Anyway, I'm open for discussion.