### PR TITLE
changes related to big grid

### DIFF
--- a/examples/6_achiever.py
+++ b/examples/6_achiever.py
@@ -48,6 +48,7 @@ if __name__ == '__main__':
     item_list, recipes = agent.rob.getItemsAndRecipesLists()
     blockdrops = agent.rob.getBlocksDropsList()
     agent.rob.updatePassableBlocks()
+    biggrid = agent.rob.getBigGrid("stone")
     mlogy = Minelogy(item_list, items_to_craft, recipes, items_to_mine, blockdrops, ore_depths)
     '''
     Currently we don't use all recipes from the game since there are some issues with

--- a/examples/6_achiever.py
+++ b/examples/6_achiever.py
@@ -48,7 +48,6 @@ if __name__ == '__main__':
     item_list, recipes = agent.rob.getItemsAndRecipesLists()
     blockdrops = agent.rob.getBlocksDropsList()
     agent.rob.updatePassableBlocks()
-    biggrid = agent.rob.getBigGrid("stone")
     mlogy = Minelogy(item_list, items_to_craft, recipes, items_to_mine, blockdrops, ore_depths)
     '''
     Currently we don't use all recipes from the game since there are some issues with

--- a/examples/skills.py
+++ b/examples/skills.py
@@ -9,8 +9,6 @@ from tagilmo.utils.mathutils import *
 
 from examples.goal import *
 
-
-
 class LookPitch(RobGoal):
 
     def __init__(self, rob, pitch, speed = 0.4):

--- a/mcdemoaux/agenttools/agent.py
+++ b/mcdemoaux/agenttools/agent.py
@@ -95,11 +95,12 @@ class NoticeBlocks:
         for index in indexes:
             block_name = list(self.block_probs_for_biggrid.keys())[index]
             probability = list(self.block_probs_for_biggrid.values())[index]
-            if random.random() < probability:
-                block_pos = rob.getBigGrid(block_name)
-                if block_pos != "Empty":
-                    pos = int_coords(block_pos)
-                    self.updateBlock(block_name, pos)
+            if block_name not in self.blocks:
+                if random.random() < probability:
+                    block_pos = rob.getBigGrid(block_name)
+                    if block_pos is not None and block_pos != "Empty":
+                        pos = int_coords(block_pos)
+                        self.updateBlock(block_name, pos)
 
     def updateBlocks(self, rob):
         grid = rob.cached['getNearGrid'][0]

--- a/mcdemoaux/agenttools/agent.py
+++ b/mcdemoaux/agenttools/agent.py
@@ -95,12 +95,13 @@ class NoticeBlocks:
         for index in indexes:
             block_name = list(self.block_probs.keys())[index]
             probability = list(self.block_probs.values())[index]
-            if block_name not in self.blocks:
-                if random.random() < probability:
-                    block_pos = rob.getBlockFromBigGrid(block_name)
-                    if block_pos is not None and block_pos != "Empty":
-                        pos = int_coords(block_pos)
-                        self.updateBlock(block_name, pos)
+            if (block_name not in self.blocks or len(self.blocks[block_name]) == 0) and random.random() < probability:
+                rob.sendCommandToFindBlock(block_name)
+            block_pos = rob.getBlockFromBigGrid()
+            if block_pos is not None and block_pos != "Empty":
+                block_pos, block_name = block_pos[:3], block_pos[3]
+                pos = int_coords(block_pos)
+                self.updateBlock(block_name, pos)
 
     def updateBlocks(self, rob):
         grid = rob.cached['getNearGrid'][0]

--- a/mcdemoaux/agenttools/agent.py
+++ b/mcdemoaux/agenttools/agent.py
@@ -62,7 +62,7 @@ class NoticeBlocks:
         self.ignore_blocks = ['air', 'grass', 'tallgrass', 'double_plant', 'dirt', 'stone']
         self.dx = 4
         self.focus_blocks = set()
-        self.block_probs_for_biggrid = {'diamond_ore' : 0.0015, 'deepslate_diamond_ore' : 0.0015,
+        self.block_probs = {'diamond_ore' : 0.0015, 'deepslate_diamond_ore' : 0.0015,
                                         'iron_ore' : 0.0015, 'deepslate_iron_ore' : 0.0015}
 
     def updateBlock(self, block, pos):
@@ -93,11 +93,11 @@ class NoticeBlocks:
     def updateBlocksFromBigGrid(self, rob, intersection):
         indexes = [i for i, e in enumerate(intersection) if e == True]
         for index in indexes:
-            block_name = list(self.block_probs_for_biggrid.keys())[index]
-            probability = list(self.block_probs_for_biggrid.values())[index]
+            block_name = list(self.block_probs.keys())[index]
+            probability = list(self.block_probs.values())[index]
             if block_name not in self.blocks:
                 if random.random() < probability:
-                    block_pos = rob.getBigGrid(block_name)
+                    block_pos = rob.getBlockFromBigGrid(block_name)
                     if block_pos is not None and block_pos != "Empty":
                         pos = int_coords(block_pos)
                         self.updateBlock(block_name, pos)
@@ -121,7 +121,7 @@ class NoticeBlocks:
                 self.removeIfMissing(grid[i], self.focus_blocks, pos)
             if bUpdate:
                 self.updateBlock(grid[i], pos)
-        intersection = [i in self.focus_blocks for i in self.block_probs_for_biggrid]
+        intersection = [i in self.focus_blocks for i in self.block_probs]
         if True in intersection:
             self.updateBlocksFromBigGrid(rob, intersection)
 

--- a/tagilmo/utils/mission_builder.py
+++ b/tagilmo/utils/mission_builder.py
@@ -158,7 +158,7 @@ class Commands:
 class Observations:
 
     def __init__(self, bAll=True, bRay=None, bFullStats=None,
-            bInvent=None, bNearby=None, bGrid=None, bBigGrid=None, bChat=None, bRecipes=False, bItems=False,
+            bInvent=None, bNearby=None, bGrid=None, bFindBlock=None, bChat=None, bRecipes=False, bItems=False,
             bHuman=None, bBlocksDrops=False, bSolidness=False):
         self.bAll = bAll
         self.bRay = bRay
@@ -166,7 +166,7 @@ class Observations:
         self.bInvent = bInvent
         self.bNearby = bNearby
         self.bGrid = bGrid
-        self.bBigGrid = bBigGrid
+        self.bFindBlock = bFindBlock
         self.gridNear = [[-5, 5], [-2, 2], [-5, 5]]
         self.gridBig = [[-25, 25], [-25, 25], [-25, 25]]
         self.bChat = bChat
@@ -215,16 +215,16 @@ class Observations:
         <max x="'''+str(self.gridNear[0][1])+'" y="'+str(self.gridNear[1][1])+'" z="'+str(self.gridNear[2][1])+'''"/>
     </Grid>
 </ObservationFromGrid>'''
-        if (self.bAll or self.bBigGrid) and not (self.bBigGrid == False):
+        if (self.bAll or self.bFindBlock) and not (self.bFindBlock == False):
             _xml += '''
-<ObservationFromBigGrid>
+<ObservationFromFindBlock>
     <Grid name="grid_big" absoluteCoords="false">
         <min x="''' + str(self.gridBig[0][0]) + '" y="' + str(self.gridBig[1][0]) + '" z="' + str(
         self.gridBig[2][0]) + '''"/>
         <max x="''' + str(self.gridBig[0][1]) + '" y="' + str(self.gridBig[1][1]) + '" z="' + str(
         self.gridBig[2][1]) + '''"/>
     </Grid>
-</ObservationFromBigGrid>'''
+</ObservationFromFindBlock>'''
         if (self.bAll or self.bChat) and not (self.bChat == False):
             _xml += "<ObservationFromChat />\n"
         #<ObservationFromRecentCommands/>

--- a/tagilmo/utils/mission_builder.py
+++ b/tagilmo/utils/mission_builder.py
@@ -158,7 +158,7 @@ class Commands:
 class Observations:
 
     def __init__(self, bAll=True, bRay=None, bFullStats=None,
-            bInvent=None, bNearby=None, bGrid=None, bChat=None, bRecipes=False, bItems=False,
+            bInvent=None, bNearby=None, bGrid=None, bBigGrid=None, bChat=None, bRecipes=False, bItems=False,
             bHuman=None, bBlocksDrops=False, bSolidness=False):
         self.bAll = bAll
         self.bRay = bRay
@@ -166,7 +166,9 @@ class Observations:
         self.bInvent = bInvent
         self.bNearby = bNearby
         self.bGrid = bGrid
+        self.bBigGrid = bBigGrid
         self.gridNear = [[-5, 5], [-2, 2], [-5, 5]]
+        self.gridBig = [[-25, 25], [-25, 25], [-25, 25]]
         self.bChat = bChat
         self.bRecipes = bRecipes
         self.bItems = bItems
@@ -212,8 +214,17 @@ class Observations:
         <min x="'''+str(self.gridNear[0][0])+'" y="'+str(self.gridNear[1][0])+'" z="'+str(self.gridNear[2][0])+'''"/>
         <max x="'''+str(self.gridNear[0][1])+'" y="'+str(self.gridNear[1][1])+'" z="'+str(self.gridNear[2][1])+'''"/>
     </Grid>
-</ObservationFromGrid>
-'''
+</ObservationFromGrid>'''
+        if (self.bAll or self.bBigGrid) and not (self.bBigGrid == False):
+            _xml += '''
+<ObservationFromBigGrid>
+    <Grid name="grid_big" absoluteCoords="false">
+        <min x="''' + str(self.gridBig[0][0]) + '" y="' + str(self.gridBig[1][0]) + '" z="' + str(
+        self.gridBig[2][0]) + '''"/>
+        <max x="''' + str(self.gridBig[0][1]) + '" y="' + str(self.gridBig[1][1]) + '" z="' + str(
+        self.gridBig[2][1]) + '''"/>
+    </Grid>
+</ObservationFromBigGrid>'''
         if (self.bAll or self.bChat) and not (self.bChat == False):
             _xml += "<ObservationFromChat />\n"
         #<ObservationFromRecentCommands/>

--- a/tagilmo/utils/vereya_wrapper.py
+++ b/tagilmo/utils/vereya_wrapper.py
@@ -344,8 +344,8 @@ class MCConnector:
     def getBlocksDropsList(self, nAgent=0):
         return self.getParticularObservation('block_item_tool_triple', nAgent)
 
-    def getBigGrid(self, nAgent=0):
-        return self.getParticularObservation('grid_big', nAgent)
+    def getBlockFromBigGrid(self, nAgent=0):
+        return self.getParticularObservation('block_pos_big_grid', nAgent)
 
     def getNonSolidBlocks(self, nAgent=0):
         return self.getParticularObservation('nonsolid_blocks', nAgent)
@@ -417,9 +417,9 @@ class RobustObserver:
         self.tick = 0.02
         self.methods = ['getNearEntities', 'getNearGrid', 'getAgentPos', 'getLineOfSights', 'getLife',
                         'getAir', 'getInventory', 'getImageFrame', 'getSegmentationFrame', 'getChat', 'getRecipeList',
-                        'getItemList', 'getHumanInputs', 'getNearPickableEntities', 'getBlocksDropsList', 'getNonSolidBlocks', 'getBigGrid']
+                        'getItemList', 'getHumanInputs', 'getNearPickableEntities', 'getBlocksDropsList', 'getNonSolidBlocks', 'getBlockFromBigGrid']
         self.canBeNone = ['getLineOfSights', 'getChat', 'getHumanInputs', 'getItemList', 'getRecipeList',
-                          'getNearPickableEntities', 'getBlocksDropsList', 'getNonSolidBlocks', 'getBigGrid']
+                          'getNearPickableEntities', 'getBlocksDropsList', 'getNonSolidBlocks', 'getBlockFromBigGrid']
 
         self.events = ['getChat', 'getHumanInputs']
 
@@ -553,10 +553,10 @@ class RobustObserver:
         triples = self.waitNotNoneObserve('getBlocksDropsList', False)
         return triples
 
-    def getBigGrid(self, block_name):
-        self.sendCommand(f'big_grid {block_name}')
-        biggrid = self.waitNotNoneObserve('getBigGrid', True)
-        return biggrid
+    def getBlockFromBigGrid(self, block_name):
+        self.sendCommand(f'find_block {block_name}')
+        blockpos = self.waitNotNoneObserve('getBlockFromBigGrid', True)
+        return blockpos
 
     def __getNonSolidBlocks(self):
         self.sendCommand('solid')

--- a/tagilmo/utils/vereya_wrapper.py
+++ b/tagilmo/utils/vereya_wrapper.py
@@ -553,8 +553,8 @@ class RobustObserver:
         triples = self.waitNotNoneObserve('getBlocksDropsList', False)
         return triples
 
-    def getBigGrid(self):
-        self.sendCommand('big_grid')
+    def getBigGrid(self, block_name):
+        self.sendCommand(f'big_grid {block_name}')
         time.sleep(1)
         biggrid = self.waitNotNoneObserve('getBigGrid', False)
         return biggrid

--- a/tagilmo/utils/vereya_wrapper.py
+++ b/tagilmo/utils/vereya_wrapper.py
@@ -555,8 +555,7 @@ class RobustObserver:
 
     def getBigGrid(self, block_name):
         self.sendCommand(f'big_grid {block_name}')
-        time.sleep(1)
-        biggrid = self.waitNotNoneObserve('getBigGrid', False)
+        biggrid = self.waitNotNoneObserve('getBigGrid', True)
         return biggrid
 
     def __getNonSolidBlocks(self):

--- a/tagilmo/utils/vereya_wrapper.py
+++ b/tagilmo/utils/vereya_wrapper.py
@@ -344,6 +344,9 @@ class MCConnector:
     def getBlocksDropsList(self, nAgent=0):
         return self.getParticularObservation('block_item_tool_triple', nAgent)
 
+    def getBigGrid(self, nAgent=0):
+        return self.getParticularObservation('grid_big', nAgent)
+
     def getNonSolidBlocks(self, nAgent=0):
         return self.getParticularObservation('nonsolid_blocks', nAgent)
 
@@ -414,9 +417,9 @@ class RobustObserver:
         self.tick = 0.02
         self.methods = ['getNearEntities', 'getNearGrid', 'getAgentPos', 'getLineOfSights', 'getLife',
                         'getAir', 'getInventory', 'getImageFrame', 'getSegmentationFrame', 'getChat', 'getRecipeList',
-                        'getItemList', 'getHumanInputs', 'getNearPickableEntities', 'getBlocksDropsList', 'getNonSolidBlocks']
+                        'getItemList', 'getHumanInputs', 'getNearPickableEntities', 'getBlocksDropsList', 'getNonSolidBlocks', 'getBigGrid']
         self.canBeNone = ['getLineOfSights', 'getChat', 'getHumanInputs', 'getItemList', 'getRecipeList',
-                          'getNearPickableEntities', 'getBlocksDropsList', 'getNonSolidBlocks']
+                          'getNearPickableEntities', 'getBlocksDropsList', 'getNonSolidBlocks', 'getBigGrid']
 
         self.events = ['getChat', 'getHumanInputs']
 
@@ -542,22 +545,24 @@ class RobustObserver:
         time.sleep(1)
         item_list = self.waitNotNoneObserve('getItemList', False)
         recipes = self.remove_mcprefix_rec(self.waitNotNoneObserve('getRecipeList', False))
-        self.sendCommand('recipes off')
-        self.sendCommand('item_list off')
         return item_list, recipes
 
     def getBlocksDropsList(self):
         self.sendCommand('blockdrops')
         time.sleep(1)
         triples = self.waitNotNoneObserve('getBlocksDropsList', False)
-        self.sendCommand('blockdrops off')
         return triples
+
+    def getBigGrid(self):
+        self.sendCommand('big_grid')
+        time.sleep(1)
+        biggrid = self.waitNotNoneObserve('getBigGrid', False)
+        return biggrid
 
     def __getNonSolidBlocks(self):
         self.sendCommand('solid')
         time.sleep(1)
         nonsolid_blocks = self.remove_mcprefix_rec(self.waitNotNoneObserve('getNonSolidBlocks', False))
-        self.sendCommand('solid off')
         return nonsolid_blocks
     
     def __get_cached_time(self, method):

--- a/tagilmo/utils/vereya_wrapper.py
+++ b/tagilmo/utils/vereya_wrapper.py
@@ -553,9 +553,11 @@ class RobustObserver:
         triples = self.waitNotNoneObserve('getBlocksDropsList', False)
         return triples
 
-    def getBlockFromBigGrid(self, block_name):
+    def sendCommandToFindBlock(self, block_name):
         self.sendCommand(f'find_block {block_name}')
-        blockpos = self.waitNotNoneObserve('getBlockFromBigGrid', True)
+
+    def getBlockFromBigGrid(self):
+        blockpos = self.cached['getBlockFromBigGrid'][0]
         return blockpos
 
     def __getNonSolidBlocks(self):

--- a/tests/vereya/test_observation.py
+++ b/tests/vereya/test_observation.py
@@ -8,6 +8,7 @@ import tagilmo.utils.mission_builder as mb
 from tagilmo.utils.vereya_wrapper import MCConnector, RobustObserver
 from base_test import BaseTest
 from common import init_mission
+import random
 
 
 logger = logging.getLogger(__name__)
@@ -54,11 +55,12 @@ class TestData(BaseTest):
     def test_observation_from_chat(self):
         logger.info("send chat ")
         self.mc.sendCommand("chat get wooden_axe")
+        time.sleep(1)
         logger.info("wait chat")
         start = time.time()
         while True:
             command = self.rob.waitNotNoneObserve('getChat', observeReq=False)
-            command = next(x[0] for x in command if x[0] is not None)
+            command = next(x[0] for x in reversed(command) if x[0] is not None)
             if command is not None:
                 break
             time.sleep(0.05)
@@ -116,6 +118,19 @@ class TestData(BaseTest):
                                 (item == 'iron_ore' and tool == 'silkt_stone_pickaxe'))
             if blockdrop['block_name'] == 'birch_leaves' and blockdrop['tool'] == 'shears':
                 self.assertEqual(blockdrop['item_name'], 'birch_leaves', "check leaves")
+
+    def test_observation_from_big_grid(self):
+        logger.debug('getting info from big grid')
+        agentpos = self.rob.getCachedObserve('getAgentPos')
+        diamond_x = int(agentpos[0] + random.randint(1, 10))
+        diamond_y = int(agentpos[1] + random.randint(1, 10))
+        diamond_z = int(agentpos[2] + random.randint(1, 10))
+        self.mc.sendCommand("chat /setblock {} {} {} minecraft:diamond_ore".format(diamond_x, diamond_y, diamond_z))
+        time.sleep(1)
+        diamond_ore_loc = self.rob.getBigGrid("diamond_ore")
+        self.assertEqual(diamond_ore_loc[0], diamond_x)
+        self.assertEqual(diamond_ore_loc[1], diamond_y)
+        self.assertEqual(diamond_ore_loc[2], diamond_z)
 
     def test_game_state(self):
         self.mc.observeProc()

--- a/tests/vereya/test_observation.py
+++ b/tests/vereya/test_observation.py
@@ -119,18 +119,19 @@ class TestData(BaseTest):
             if blockdrop['block_name'] == 'birch_leaves' and blockdrop['tool'] == 'shears':
                 self.assertEqual(blockdrop['item_name'], 'birch_leaves', "check leaves")
 
-    def test_observation_from_big_grid(self):
-        logger.debug('getting info from big grid')
+    def test_observation_from_find_block(self):
+        logger.debug('finding block in big grid')
         agentpos = self.rob.getCachedObserve('getAgentPos')
         diamond_x = int(agentpos[0] + random.randint(1, 10))
         diamond_y = int(agentpos[1] + random.randint(1, 10))
         diamond_z = int(agentpos[2] + random.randint(1, 10))
         self.mc.sendCommand("chat /setblock {} {} {} minecraft:diamond_ore".format(diamond_x, diamond_y, diamond_z))
         time.sleep(1)
-        diamond_ore_loc = self.rob.getBigGrid("diamond_ore")
+        diamond_ore_loc = self.rob.getBlockFromBigGrid("diamond_ore")
         self.assertEqual(diamond_ore_loc[0], diamond_x)
         self.assertEqual(diamond_ore_loc[1], diamond_y)
         self.assertEqual(diamond_ore_loc[2], diamond_z)
+        self.mc.sendCommand("chat /setblock {} {} {} minecraft:air".format(diamond_x, diamond_y, diamond_z))
 
     def test_game_state(self):
         self.mc.observeProc()


### PR DESCRIPTION
So, those changes are for new functionality - getting grid bigger than normal one. Current size of bigger grid is [-25;25] for each dimension. 

If you want to get this big grid for example in achiever.py just for test, here is the line `biggrid = agent.rob.getBigGrid()` . Currently this big grid not in use but it could be. 

To test this PR you need to use[ this PR](https://github.com/trueagi-io/Vereya/pull/55) from Vereya